### PR TITLE
Enable specifying a fallback shard iterator type if no sequence numbe…

### DIFF
--- a/lib/fluent/plugin/in_kinesis.rb
+++ b/lib/fluent/plugin/in_kinesis.rb
@@ -52,6 +52,7 @@ module FluentPluginKinesis
     config_param :describe_shard,         :bool,    :default => false,  :secret => true
     config_param :describe_use_shards,    :array,   :default => [],     :secret => true
     config_param :retries_on_get_records, :integer, :default => 3
+    config_param :fallback_shard_iterator_type, :string,  :default => 'TRIM_HORIZON', :secret => true
     
     def configure(conf)
       super

--- a/lib/fluent/plugin/kinesis_shard.rb
+++ b/lib/fluent/plugin/kinesis_shard.rb
@@ -45,7 +45,7 @@ module KinesisShard
   def get_shard_iterator_info(shard_id='', last_sequence_number='')
     if last_sequence_number.empty?
       shard_iterator_info = @client.get_shard_iterator(
-        stream_name: @stream_name, shard_id: shard_id, shard_iterator_type: 'TRIM_HORIZON')
+        stream_name: @stream_name, shard_id: shard_id, shard_iterator_type: @fallback_shard_iterator_type)
     else
       shard_iterator_info = @client.get_shard_iterator(
         stream_name: @stream_name, shard_id: shard_id, shard_iterator_type: 'AFTER_SEQUENCE_NUMBER', starting_sequence_number: last_sequence_number)


### PR DESCRIPTION
…r is available

This is useful if you for example want to use LATEST instead of TRIM_HORIZON.